### PR TITLE
[oc rsync] supress non-error messages 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,6 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.6
   - repo: https://github.com/prettier/prettier
     rev: 2.0.5
     hooks:

--- a/sandcastle/api.py
+++ b/sandcastle/api.py
@@ -585,7 +585,7 @@ class Sandcastle(object):
             "rsync",
             exclude,
             include,
-            "--progress=true",
+            "--quiet=true",  # avoid huge logs
             f"--namespace={self.k8s_namespace_name}",
             f"{local_path}/",  # ??? rsync doesn't work without the trailing /
             f"{self.pod_name}:{pod_dir}",
@@ -606,7 +606,7 @@ class Sandcastle(object):
                 "oc",
                 "rsync",
                 "--delete",  # delete files in local_dir which are not in pod_dir
-                "--progress=true",
+                "--quiet=true",  # avoid huge logs
                 f"--namespace={self.k8s_namespace_name}",
                 f"{self.pod_name}:{pod_dir}/",  # trailing / to copy only content of dir
                 f"{local_dir}",


### PR DESCRIPTION
`rsync` reports each synced file separately, which makes the log huge. Report only errors now.

Just removing `--progress` (without adding `--quiet`) would only remove the progress numbers, but the big files list would remain.