### PR TITLE
pin kubernetes to 12

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -3,6 +3,7 @@
 FROM docker.io/usercont/sandcastle
 
 COPY tests/requirements.txt ./tests/
+COPY .git setup.py setup.cfg ./
 RUN ansible-playbook -vv -c local -t with-sandcastle-deps -i localhost, install-rpm-packages.yaml \
     && dnf clean all
 

--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -61,8 +61,13 @@
           - origin-clients # oc cp
           - python3-pytest # tests
           - python3-flexmock
-          - python3-kubernetes
         state: present
+      tags:
+        - with-sandcastle-deps
+    - name: Install kubernetes client
+      pip:
+        executable: /usr/bin/pip3
+        name: kubernetes==12.0.1
       tags:
         - with-sandcastle-deps
     - name: Install tests requirements

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,8 @@ keywords =
 [options]
 packages = find:
 install_requires =
-    # kube client changes API b/w major versions
-    kubernetes<=12
+    # kube client changes API b/w major versions and we're on 12 now
+    kubernetes==12.0.1
 python_requires = >=3.6
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
because our current version requires 12 and we can't be sure that 13
won't break the api