### PR TITLE
Install sassc into sandbox

### DIFF
--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -24,6 +24,7 @@
           - sed
           - gawk
           - npm # cockpit project needs these
+          - sassc # cockpit project needs these
           - python3-docutils # for those who generates man pages from README.md
           - json-c-devel # \
           - systemd-devel # https://github.com/Scribery/tlog/pull/274


### PR DESCRIPTION
All cockpit projects now moved into using sassc and without this package
it fails to build archive.