### PR TITLE
prepare sandcastle for running multiple commands in a single sandbox

### DIFF
--- a/tests/e2e/test_ironman.py
+++ b/tests/e2e/test_ironman.py
@@ -56,6 +56,21 @@ def purge_dir_content(di: Path):
             rmtree(item)
 
 
+def test_exec_env():
+    o = Sandcastle(image_reference=SANDBOX_IMAGE, k8s_namespace_name=NAMESPACE)
+    o.run()
+    try:
+        env_list = o.exec(
+            command=["bash", "-c", "env"], env={"A": None, "B": "", "C": "c", "D": 1}
+        )
+        assert "A=\n" in env_list
+        assert "B=\n" in env_list
+        assert "C=c\n" in env_list
+        assert "D=1\n" in env_list
+    finally:
+        o.delete_pod()
+
+
 def test_run_failure():
     o = Sandcastle(image_reference=SANDBOX_IMAGE, k8s_namespace_name=NAMESPACE)
     try:
@@ -438,6 +453,7 @@ def test_changing_mode(tmp_path):
     "test_name,kwargs",
     (
         ("test_exec", None),
+        ("test_exec_env", None),
         ("test_md_exec", None),
         ("test_run_failure", None),
         ("test_dir_sync", {"with_pv_at": "/asdqwe"}),

--- a/tests/e2e/test_ironman.py
+++ b/tests/e2e/test_ironman.py
@@ -236,6 +236,7 @@ def test_md_multiple_exec(tmp_path):
         assert zxc.is_file()
         zxc.write_text("vbnm")
         assert "vbnm" == o.exec(command=["cat", "./zxc"])
+        assert o.exec(command=["pwd"], cwd="stark/").rstrip("\n").endswith("/stark")
     finally:
         o.delete_pod()
 

--- a/tests/e2e/test_ironman.py
+++ b/tests/e2e/test_ironman.py
@@ -217,7 +217,10 @@ def test_md_multiple_exec(tmp_path):
         o.exec(command=["touch", "./stark/asd"])
         assert tmp_path.joinpath("stark/asd").is_file()
         o.exec(command=["touch", "./zxc"])
-        assert tmp_path.joinpath("zxc").is_file()
+        zxc = tmp_path.joinpath("zxc")
+        assert zxc.is_file()
+        zxc.write_text("vbnm")
+        assert "vbnm" == o.exec(command=["cat", "./zxc"])
     finally:
         o.delete_pod()
 

--- a/tests/e2e/test_ironman.py
+++ b/tests/e2e/test_ironman.py
@@ -56,16 +56,6 @@ def purge_dir_content(di: Path):
             rmtree(item)
 
 
-def test_basic_e2e_inside():
-    o = Sandcastle(
-        image_reference=SANDBOX_IMAGE, k8s_namespace_name=NAMESPACE, pod_name="lllollz"
-    )
-    try:
-        o.run(command=["ls", "-lha"])
-    finally:
-        o.delete_pod()
-
-
 def test_run_failure():
     o = Sandcastle(image_reference=SANDBOX_IMAGE, k8s_namespace_name=NAMESPACE)
     try:
@@ -444,7 +434,6 @@ def test_changing_mode(tmp_path):
 @pytest.mark.parametrize(
     "test_name,kwargs",
     (
-        ("test_basic_e2e_inside", None),
         ("test_exec", None),
         ("test_md_exec", None),
         ("test_run_failure", None),


### PR DESCRIPTION
Please read commit messages to get more info.

The main reason for this PR is to implement env and cmd args for exec so that we can have one sandbox pod and running multiple commands in it via packit-service