### PR TITLE
exec output: read while the conn is open

### DIFF
--- a/sandcastle/api.py
+++ b/sandcastle/api.py
@@ -533,11 +533,14 @@ class Sandcastle(object):
         try:
             # https://github.com/packit-service/sandcastle/issues/23
             # even with a >0 number or ==0, select tends to block
-            ws_client.run_forever(timeout=WEBSOCKET_CALL_TIMEOUT)
-            errors = ws_client.read_channel(ERROR_CHANNEL)
-            logger.debug("%s", errors)
-            # read_all would consume ERR_CHANNEL, so read_all needs to be last
-            response = ws_client.read_all()
+            response = ""
+            errors = ""
+            while ws_client.is_open():
+                ws_client.run_forever(timeout=WEBSOCKET_CALL_TIMEOUT)
+                errors += ws_client.read_channel(ERROR_CHANNEL)
+                logger.debug("%s", errors)
+                # read_all would consume ERR_CHANNEL, so read_all needs to be last
+                response += ws_client.read_all()
             if errors:
                 # errors = '{"metadata":{},"status":"Success"}'
                 j = json.loads(errors)

--- a/tests/e2e/test_ironman.py
+++ b/tests/e2e/test_ironman.py
@@ -277,7 +277,7 @@ def test_command_long_output(tmp_path):
             "master",
             # this downloads megabytes of npm modules
             # and verifies we can run npm in sandcastle
-            ["make", "dist-gzip"],
+            ["make", "srpm"],
         ),
     ),
 )
@@ -296,10 +296,9 @@ def test_md_e2e(tmp_path, git_url, branch, command):
     )
     o.run()
     try:
-        output = o.exec(command=["packit", "--debug", "srpm"])
+        output = o.exec(command=command)
         print(output)
-        if command == PACKIT_SRPM_CMD:
-            assert list(t.glob("*.src.rpm"))
+        assert list(t.glob("*.src.rpm"))
         o.exec(command=["packit", "--help"])
 
         with pytest.raises(SandcastleCommandFailed) as ex:


### PR DESCRIPTION
we were naive...

...actually, I was

    ws_client.run_forever(timeout=WEBSOCKET_CALL_TIMEOUT)
    errors = ws_client.read_channel(ERROR_CHANNEL)
    response += ws_client.read_all()

My original thinking was that once these 3 calls finish, our exec is
done and we get its output.

WRONG

This only waits for 30 seconds and then halts - so when a command takes
more than 30 seconds (hello npm) to finish, the stream of data is just
cut, no exception raised, nothing suspicious in the logs, and Tomas is
freaking out how come the tarball is not in the repo.

this commit implements:
* read the data while the connection is open
* tests: actually make sure that when we create a srpm from the
  cockpit-podman checkout the file is in there

Resolves https://github.com/packit/packit-service/issues/917