### PR TITLE
install python3-wheel to sandbox

### DIFF
--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -26,6 +26,7 @@
           - npm # cockpit project needs these
           - sassc # cockpit project needs these
           - python3-docutils # for those who generates man pages from README.md
+          - python3-wheel # for python projects
           - json-c-devel # \
           - systemd-devel # https://github.com/Scribery/tlog/pull/274
           - libcurl-devel # /


### PR DESCRIPTION
running

    ['python3', 'setup.py', 'sdist', '--dist-dir', '.']

outputs

    WARNING: The wheel package is not available.
    $VERSION

which is pretty bad, that's not what we wanted

https://prod.packit.dev/srpm-build/13492/logs
https://sentry.io/organizations/red-hat-0p/issues/2201368478