### PR TITLE
retry create pod: endure longer

### DIFF
--- a/sandcastle/api.py
+++ b/sandcastle/api.py
@@ -322,7 +322,10 @@ class Sandcastle(object):
 
         :return: response from the API server
         """
-        # if we hit timebound quota, let's try 5 times with expo backoff
+        # if we hit timebound quota, let's try RETRY_CREATE_POD_MAX times with expo backoff
+        # 2 ** 7 = 128 = 2 minutes
+        # 2 ** 8 = 256 = 4 minutes
+        # in total we try for ~8 minutes
         for idx in range(1, RETRY_CREATE_POD_MAX):
             try:
                 logger.debug(f"Creating sandbox pod via kubernetes API, try {idx}")
@@ -341,7 +344,7 @@ class Sandcastle(object):
                 #   "message":"pods \"docker-io-usercont-sandcastle-prod-...\" is forbidden...
                 #     "code":403}
                 if "403" in exc_str:  # forbidden
-                    sleep_time = 3 ** idx
+                    sleep_time = 2 ** idx
                     logger.debug(f"Trying again in {sleep_time}s")
                     time.sleep(sleep_time)
                 else:

--- a/sandcastle/constants.py
+++ b/sandcastle/constants.py
@@ -10,4 +10,4 @@ RETRY_INIT_WS_CLIENT_MAX = 5
 # when calling k8s' API to create a pod, we may get an error that
 # resources are not available at that moment (timebound quota) and may
 # be later - so let's retry this many times
-RETRY_CREATE_POD_MAX = 6
+RETRY_CREATE_POD_MAX = 8


### PR DESCRIPTION
We now know this code actually works, sample logs from production:

    [2021-02-10 15:01:07,670: DEBUG/ForkPoolWorker-1] Creating sandbox pod via kubernetes API, try 1
    [2021-02-10 15:01:07,683: INFO/ForkPoolWorker-1] Unable to create the pod: (403)
    [2021-02-10 15:01:07,683: DEBUG/ForkPoolWorker-1] Trying again in 3s
    [2021-02-10 15:01:10,684: DEBUG/ForkPoolWorker-1] Creating sandbox pod via kubernetes API, try 2
    [2021-02-10 15:01:10,706: INFO/ForkPoolWorker-1] Unable to create the pod: (403)
    [2021-02-10 15:01:10,706: DEBUG/ForkPoolWorker-1] Trying again in 9s
    [2021-02-10 15:01:19,709: DEBUG/ForkPoolWorker-1] Creating sandbox pod via kubernetes API, try 3
    [2021-02-10 15:01:19,722: INFO/ForkPoolWorker-1] Unable to create the pod: (403)
    [2021-02-10 15:01:19,723: DEBUG/ForkPoolWorker-1] Trying again in 27s
    [2021-02-10 15:01:46,749: DEBUG/ForkPoolWorker-1] Creating sandbox pod via kubernetes API, try 4
    [2021-02-10 15:01:46,785: DEBUG/ForkPoolWorker-1] pod = 'docker-io-usercont-sandcastle-prod-20210210-150107643708'

In the case above, we succeeded on the 4th try - we had to wait 40 seconds.

Waiting "{2**8}s" may be too extreme but since this is happening too often I
believe this is a good balance between resilience and trying something without
being able to succeed.