### PR TITLE
setup_env_in_openshift: drop `set -x`

### DIFF
--- a/files/setup_env_in_openshift.sh
+++ b/files/setup_env_in_openshift.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/bash
 
-set -x
+# uncomment for debugging, otherwise leave commented out, we don't
+# want to provide output from this script to users to confuse them
+# set -x
 
 # Generate passwd file based on current uid, needed for fedpkg
 grep -v ^sandcastle /etc/passwd > "${HOME}/passwd"


### PR DESCRIPTION
set -x is great for debugging but we should not print content of that
script to users - would be just confusing

we need this in stable for tests to pass in #93