### PR TITLE
exec: command fails: copy data out gracefully

### DIFF
--- a/files/container-cmd.sh
+++ b/files/container-cmd.sh
@@ -4,5 +4,5 @@ set -x
 
 source ./setup_env_in_openshift.sh
 
-# 10 minutes is a default timeout for the sandbox pod
-sleep 600
+# 30 minutes is a default timeout for the sandbox pod
+sleep 1800

--- a/sandcastle/api.py
+++ b/sandcastle/api.py
@@ -473,7 +473,6 @@ class Sandcastle(object):
         """
         self.deploy_pod(command=command)
         logger.info("Sandbox pod is deployed.")
-        return self.get_logs()
 
     def _do_exec(
         self, command: List[str], preload_content=True

--- a/tests/e2e/test_ironman.py
+++ b/tests/e2e/test_ironman.py
@@ -1,24 +1,5 @@
-# MIT License
-#
-# Copyright (c) 2018-2019 Red Hat, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
 import json
 import os
 from pathlib import Path

--- a/tests/unit/test_pod_and_env.py
+++ b/tests/unit/test_pod_and_env.py
@@ -213,20 +213,20 @@ def test_env_image_vars(env_dict, env_image_vars):
 
 
 def test_manifest(init_openshift_deployer):
-    od: Sandcastle = init_openshift_deployer
-    assert od
+    sandcastle: Sandcastle = init_openshift_deployer
+    assert sandcastle
     KEY = "UPSTREAM_NAME"
     VALUE = "COLIN"
     expected_manifest = {
         "apiVersion": "v1",
         "kind": "Pod",
-        "metadata": {"name": od.pod_name},
+        "metadata": {"name": sandcastle.pod_name},
         "spec": {
             "automountServiceAccountToken": False,
             "containers": [
                 {
-                    "image": od.image_reference,
-                    "name": od.pod_name,
+                    "image": sandcastle.image_reference,
+                    "name": sandcastle.pod_name,
                     "env": [{"name": KEY, "value": VALUE}],
                     "imagePullPolicy": "IfNotPresent",
                     "resources": {
@@ -238,6 +238,6 @@ def test_manifest(init_openshift_deployer):
             "restartPolicy": "Never",
         },
     }
-    od.env_vars = {KEY: VALUE}
-    pod_manifest = od.create_pod_manifest()
-    assert pod_manifest == expected_manifest
+    sandcastle.env_vars = {KEY: VALUE}
+    sandcastle.set_pod_manifest()
+    assert sandcastle.pod_manifest == expected_manifest


### PR DESCRIPTION
```
When the pod dies and exec is still happening, docker/openshift kill the
exec with rc=137. Copying data after this happens ends with:

https://prod.packit.dev/srpm-build/16278/logs

    WARNING: cannot use rsync: rsync not available in container

Would be nice if oc actually told us the pod is dead and not that
useless warning.

So instead of breaking there, we eat the exception and continue
execution to raise SandcastleCommandFailed which contains all the data
regarding the failure.

Those "weird" changes in api.py are done for sake of the new test case.
```

\+
```
increase pod timeout to 30 minutes

use case: it takes a long time to create an archive for RPM CI builds so
we need to wait for it before proceding with creating an SRPM
```
