### PR TITLE
Revert "Build using Ubuntu 18.04"

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -9,9 +9,7 @@ jobs:
   build-n-push:
     # To not run in forks
     if: github.repository_owner == 'packit'
-    # https://github.com/redhat-actions/buildah-build/issues/45
-    # runs-on: ubuntu-latest
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:


### PR DESCRIPTION
This reverts commit 63bcb513dfe136a768cdc7878a7e44f05b904427.

Should be fixed in buildah-build v2.4