### PR TITLE
Install some development packages into sandbox for cockpit

### DIFF
--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -23,8 +23,6 @@
           - which
           - sed
           - gawk
-          - npm # cockpit project needs these
-          - sassc # cockpit project needs these
           - python3-docutils # for those who generates man pages from README.md
           - python3-wheel # for python projects
           - json-c-devel # \
@@ -36,6 +34,13 @@
           - rust # needed for rust-based projects
           - cargo #
           - rubygems # https://github.com/packit/packit-service/issues/771
+          # these are for cockpit
+          - npm
+          - sassc
+          - json-glib-devel
+          - gnutls-devel
+          - krb5-devel
+          - pam-devel
           # these are for anaconda
           - glib2-devel
           - gettext-devel


### PR DESCRIPTION
Cockpit changed how it stores its pre-built node webpacks [1] (building
webpacks in sandcastle takes way too much time/RAM). As this does not
store the full dist tarballs any more, they now need to be built in
sandcastle with `make dist`. This is still quick as it does not need to
involve npm/node, but ./configure still needs a few non-optional build
dependencies to succeed: json-glib-devel, gnutls-devel, krb5-devel, and
pam-devel.

Keep npm/sassc for starter-kit and cockpit-podman, which are small
enough to not need the whole caching machinery.

Move all cockpit project related packages into their own block similar
to anaconda.

[1] https://github.com/cockpit-project/cockpit/pull/15748

-----

Currently our packit builds [fail like this](https://dashboard.packit.dev/results/srpm-builds/22260). I can reproduce this locally with

    podman run -ti --rm --memory 768MB -v $PWD:/src -w /src quay.io/packit/sandcastle:prod test/make_dist.py --wait

With these additional packages, and manually installing these new build deps, this succeeds. I need to disable optional dependencies with `AUTOGEN_CONFIGURE_ARGS="--disable-polkit --disable-ssh --disable-pcp --disable-doc"`, but that is no problem.