### PR TITLE
verify `packit srpm` works correctly for cockpit-podman

### DIFF
--- a/tests/e2e/test_ironman.py
+++ b/tests/e2e/test_ironman.py
@@ -320,7 +320,7 @@ def test_user_is_set(tmp_path):
             "master",
             # this downloads megabytes of npm modules
             # and verifies we can run npm in sandcastle
-            ["make", "srpm"],
+            PACKIT_SRPM_CMD,
         ),
     ),
 )


### PR DESCRIPTION
the former limit is no longer enough for cockpit-podman:
https://softwarefactory-project.io/zuul/t/packit-service/build/5c353ec9ff8d4c2eb899b599a514282d/log/job-output.txt#4402

Edit: but locally it works