### PR TITLE
Re-drop sandbox development packages for cockpit

### DIFF
--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -37,10 +37,6 @@
           # these are for cockpit
           - npm
           - sassc
-          - json-glib-devel
-          - gnutls-devel
-          - krb5-devel
-          - pam-devel
           # these are for anaconda
           - glib2-devel
           - gettext-devel


### PR DESCRIPTION
Revert the additional packages from commit a975e2333383fd, but keep the
new sorting order.

cockpit's `make dist` became a lot less demanding for packit:
https://github.com/cockpit-project/cockpit/pull/15778

----

This is of course not urgent at all, and if you'd rather keep these additional packages, that's fine for me. I toss that here to keep the sandcastle as small as possible.

Sorry for the extra noise!