### PR TITLE
sandbox: install xmlto

### DIFF
--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -37,6 +37,7 @@
           # these are for cockpit
           - npm
           - sassc
+          - xmlto
           # these are for anaconda
           - glib2-devel
           - gettext-devel


### PR DESCRIPTION
This is required for building docs for cockpit.

See cockpit-project/cockpit#15948 for our current workaround.