### PR TITLE
VolumeSpec: enable setting read_only mounts

### DIFF
--- a/tests/unit/test_pod_and_env.py
+++ b/tests/unit/test_pod_and_env.py
@@ -104,6 +104,7 @@ def pod_json_deployed():
                         {
                             "name": "packit-sandcastle",
                             "mountPath": "/tmp/packit-sandcastle",
+                            "readOnly": False,
                         }
                     ],
                     "terminationMessagePath": "/dev/termination-log",


### PR DESCRIPTION
Fixes https://github.com/packit/sandcastle/issues/141

---

You can now mount volumes read-only in the sandbox.