### PR TITLE
sandbox: install selinux-policy

### DIFF
--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -37,6 +37,7 @@
           # these are for cockpit
           - npm
           - sassc
+          - selinux-policy
           - xmlto
           # these are for anaconda
           - glib2-devel


### PR DESCRIPTION
This is required for the selinux policy macros that may appear in some
spec files (in particular, for Cockpit).

See fails in #16870.  We can work around this for now, but it might be nice to support this.