### PR TITLE
Don't install python2-setuptools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,16 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-ast
+      - id: check-builtin-literals
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
       - id: check-merge-conflict
+      - id: check-symlinks
       - id: check-yaml
       - id: detect-private-key
         exclude: tests/conftest.py
       - id: end-of-file-fixer
+      - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
@@ -34,7 +39,7 @@ repos:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
   - repo: https://github.com/packit/pre-commit-hooks
-    rev: 1da916777f5cc26ecf221b15e58ca51891d26d94
+    rev: 3bf9afc5ede12a4ee26e9451f306edf255749396
     hooks:
       - id: check-rebase
         args:

--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -30,8 +30,6 @@
           - libcurl-devel # /
           - python3-setuptools_scm # ansible-lint
           - python3-zanata-client # for those who use zanata for localization
-          - python2 # https://github.com/packit-service/sandcastle/issues/49
-          - python2-setuptools # /
           - rust # needed for rust-based projects
           - cargo #
           - rubygems # https://github.com/packit/packit-service/issues/771


### PR DESCRIPTION
We recently [bumped the base image to F35](https://github.com/packit/deployment/pull/306) and [there's no python2-setuptools in F35](
https://src.fedoraproject.org/rpms/python2-setuptools).

So we can either remove it or base sandcastle image on F34.
It was originally added as a reaction to @bocekm's #49.
Michal, do you still need it? I don't see it in [convert2rhel's .packit.yaml](https://github.com/oamg/convert2rhel/blob/main/.packit.yaml)
