### PR TITLE
tests: drop test_md_e2e

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,6 @@ TEST_IMAGE_BASENAME = "sandcastle-tests"
 TEST_IMAGE_NAME = f"quay.io/packit/{TEST_IMAGE_BASENAME}"
 NAMESPACE = "myproject"
 SANDCASTLE_MOUNTPOINT = "/sandcastle"
-PACKIT_SRPM_CMD = ["packit", "--debug", "srpm"]
 
 
 # exterminate!


### PR DESCRIPTION
The test case was pretty useful during the early development stages of
sandcastle. Now that we want to build SRPMs in Copr, it's getting
irrelevant.

The current failures are caused by an old version of packit that does
not understand the newest schema:

```
packit.exceptions.PackitConfigException: Cannot parse package config: ValidationError(
    {'jobs': {0: {'srpm_build_deps': ['Unknown field.']}}, 'srpm_build_deps': ['Unknown field.']}).
```

There is no point in having these tests anymore since they test Packit
and not sandcastle.

BEGIN RELEASE NOTES
N/A
END RELEASE NOTES