### PR TITLE
Install OKD CLI (oc) & Don't set locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 # It should contain basic utilities, such as git, make, rpmbuild, etc.
 FROM quay.io/packit/base
 
-ENV LC_ALL=C \
-    PYTHONDONTWRITEBYTECODE=yes \
+ENV PYTHONDONTWRITEBYTECODE=yes \
     USER=sandcastle \
     HOME=/home/sandcastle
 

--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -3,7 +3,7 @@
   hosts: all
   tasks:
     - name: Install basic utilities which should be in a sandbox.
-      dnf:
+      ansible.builtin.dnf:
         name:
           - rsync # oc rsync worker:/sandcastle <-> sandcastle-pod
           - make
@@ -54,7 +54,7 @@
       tags:
         - basic-image
     - name: Install all RPM packages needed to hack on sandcastle.
-      dnf:
+      ansible.builtin.dnf:
         name:
           - git-core
           - python3-devel
@@ -69,19 +69,19 @@
       tags:
         - with-sandcastle-deps
     - name: Install Python client for kubernetes
-      pip:
+      ansible.builtin.pip:
         name: kubernetes==12.0.1
       tags:
         - with-sandcastle-deps
     - name: Install OKD CLI (oc)
       ansible.builtin.unarchive:
         src: https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
-        remote_src: yes
+        remote_src: true
         dest: /usr/bin/
       tags:
         - with-sandcastle-deps
     - name: Install tests requirements
-      pip:
+      ansible.builtin.pip:
         requirements: "{{ lookup('env','PWD') }}/tests/requirements.txt"
       tags:
         - with-sandcastle-deps

--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -63,21 +63,25 @@
           - python3-setuptools
           - python3-setuptools_scm
           - python3-setuptools_scm_git_archive
-          - origin-clients # oc cp
           - python3-pytest # tests
           - python3-flexmock
         state: present
       tags:
         - with-sandcastle-deps
-    - name: Install kubernetes client
+    - name: Install Python client for kubernetes
       pip:
-        executable: /usr/bin/pip3
         name: kubernetes==12.0.1
+      tags:
+        - with-sandcastle-deps
+    - name: Install OKD CLI (oc)
+      ansible.builtin.unarchive:
+        src: https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+        remote_src: yes
+        dest: /usr/bin/
       tags:
         - with-sandcastle-deps
     - name: Install tests requirements
       pip:
-        executable: /usr/bin/pip3
         requirements: "{{ lookup('env','PWD') }}/tests/requirements.txt"
       tags:
         - with-sandcastle-deps

--- a/files/setup-openshift.yaml
+++ b/files/setup-openshift.yaml
@@ -4,10 +4,10 @@
   tasks:
     # https://github.com/packit-service/sandcastle#developing-sandcastle
     - name: Add permissions for service account
-      command: oc adm policy add-role-to-user edit system:serviceaccount:myproject:default
+      ansible.builtin.command: oc adm policy add-role-to-user edit system:serviceaccount:myproject:default
       become: true
     - name: grant everyone access to {{ item }} so we can use it inside test container
-      file:
+      ansible.builtin.file:
         path: "{{ item }}"
         mode: "0775"
       loop:

--- a/files/tasks/zuul-project-setup.yaml
+++ b/files/tasks/zuul-project-setup.yaml
@@ -1,22 +1,22 @@
 ---
-- set_fact:
+- ansible.builtin.set_fact:
     project_dir: "{{ playbook_dir }}/.."
-- set_fact:
+- ansible.builtin.set_fact:
     project_dir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
   when: zuul is defined
-- name: stat {{ project_dir }}
-  stat:
+- name: Stat {{ project_dir }}
+  ansible.builtin.stat:
     path: "{{ project_dir }}"
   tags:
     - no-cache
   register: src_path
-- name: Let's make sure {{ project_dir }} is present
-  assert:
+- name: Make sure project_dir is present
+  ansible.builtin.assert:
     that:
       - "src_path.stat.isdir"
-- name: check ~/.kube/config
-  stat:
+- name: Check ~/.kube/config
+  ansible.builtin.stat:
     path: ~/.kube/config
   register: kube_config_stat
-- debug:
+- ansible.builtin.debug:
     var: kube_config_stat

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -4,12 +4,12 @@
   tasks:
     - include_tasks: tasks/zuul-project-setup.yaml
     - name: Build test image
-      command: make build-test-image
+      ansible.builtin.command: make build-test-image
       args:
         chdir: "{{ project_dir }}"
       become: true
     - name: Run tests
-      command: make check-in-container
+      ansible.builtin.command: make check-in-container
       args:
         chdir: "{{ project_dir }}"
       become: true


### PR DESCRIPTION
To avoid: `ERROR: Ansible requires the locale encoding to be UTF-8; Detected None.` after [bumping base image to F37](https://github.com/packit/deployment/pull/421).

It was added in 5e37bb93d to silence Autotools rants. At that time we were setting also `LANG`, which we don't anymore, so let's stop setting `LC_ALL` as well and see if we still need any locale tweaking.