### PR TITLE
Don't install weak dependencies

### DIFF
--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -51,6 +51,7 @@
           # so people can manipulate their upstream fmf definitions while proposing downstream
           - fmf
         state: present
+        install_weak_deps: False
       tags:
         - basic-image
     - name: Install all RPM packages needed to hack on sandcastle.


### PR DESCRIPTION
If something needs them, let's include them explicitly.

The reason is `gobject-introspection-devel` having a weak dependency on `python3-crypto` which is [obsolete upstream and contains a critical vulnerability](https://bugzilla.redhat.com/show_bug.cgi?id=1409754#c4).