### PR TITLE
Use CentOS Stream9 as a base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default sandbox container image to run untrusted commands.
 # It should contain basic utilities, such as git, make, rpmbuild, etc.
-FROM quay.io/packit/base
+FROM quay.io/packit/base:c9s
 
 ENV PYTHONDONTWRITEBYTECODE=yes \
     USER=sandcastle \

--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -42,7 +42,6 @@
           - gettext-devel
           - python3-polib
           - gobject-introspection-devel
-          - golist # podman
           - glade-devel
           - libxklavier-devel
           - libarchive-devel

--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -18,7 +18,6 @@
           - meson
           - ninja-build
           - wget
-          - curl
           - findutils
           - which
           - sed
@@ -65,7 +64,7 @@
           - python3-setuptools_scm
           - python3-setuptools_scm_git_archive
           - python3-pytest # tests
-          - python3-flexmock
+        #          - python3-flexmock  # RHBZ#2120251
         state: present
       tags:
         - with-sandcastle-deps


### PR DESCRIPTION
All the [dependencies](https://github.com/packit/deployment/issues/410#issuecomment-1346559034) are available now so we can eventually switch. We don't need to do it now, I'm just opening this to have it tracked, that it is possible.

`curl-minimal` (smaller, fewer dependencies than `curl`) is already part of the image.
If we really needed `curl`, we'd probably need to use `allowerasing` as they conflict with each other.

Related to packit/deployment#410
