### PR TITLE
fix: allow requesting PVCs on MP+

### DIFF
--- a/sandcastle/api.py
+++ b/sandcastle/api.py
@@ -130,14 +130,15 @@ class Sandcastle(object):
         mapped_dir: Optional[MappedDir] = None,
     ):
         """
-        :param image_reference: the pod will use this image
-        :param k8s_namespace_name: name of the namespace to deploy into
-        :param env_vars: additional environment variables to set in the pod
-        :param pod_name: name the pod like this, if not specified, generate something long and ugly
-        :param working_dir: path within the pod where we run commands by default
-        :param service_account_name: run the pod using this service account
-        :param volume_mounts: set these volume mounts in the sandbox
-        :param mapped_dir, a mapping between a local dir which should be copied
+        Args:
+            image_reference: the pod will use this image
+            k8s_namespace_name: name of the namespace to deploy into
+            env_vars: additional environment variables to set in the pod
+            pod_name: name the pod like this, if not specified, generate something long and ugly
+            working_dir: path within the pod where we run commands by default
+            service_account_name: run the pod using this service account
+            volume_mounts: set these volume mounts in the sandbox
+            mapped_dir: a mapping between a local dir which should be copied
                to the sandbox, and then copied back once all the work is done
                when this is set, working_dir args is being ignored and sandcastle invokes
                all exec commands in the working dir of the mapped dir

--- a/sandcastle/kube.py
+++ b/sandcastle/kube.py
@@ -31,7 +31,20 @@ class PVC:
             "spec": {
                 "accessModes": self.access_modes,
                 "resources": {"requests": {"storage": self.storage_size}},
+                # aws-ebs is managed by us, costs less, smaller throughput
+                # aws-efs* is managed by AWS, is faster
+                "storageClassName": "aws-ebs",
             },
             "apiVersion": "v1",
-            "metadata": {"name": self.claim_name},
+            "metadata": {
+                "name": self.claim_name,
+                "annotations": {
+                    # after deleting »the PVC«, the data are deleted
+                    "kubernetes.io/reclaimPolicy": "Delete",
+                },
+                "labels": {
+                    # TODO: adjust after deploying the prod if need be…
+                    "paas.redhat.com/appcode": "PCKT-002",
+                },
+            },
         }

--- a/tests/unit/test_pod_and_env.py
+++ b/tests/unit/test_pod_and_env.py
@@ -203,7 +203,10 @@ def test_manifest(init_openshift_deployer):
     expected_manifest = {
         "apiVersion": "v1",
         "kind": "Pod",
-        "metadata": {"name": sandcastle.pod_name},
+        "metadata": {
+            "name": sandcastle.pod_name,
+            "labels": {"paas.redhat.com/appcode": None},
+        },
         "spec": {
             "automountServiceAccountToken": False,
             "containers": [


### PR DESCRIPTION
* add a storage class:
  * MP+ uses `aws-ebs` or `aws-efs*`
  * Automotive uses `aws-ebs`, but masked as `gp2`
* add reclaim policy annotation
  * for details see https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaim-policy
* add appcode

Fixes #190

TODO:

- [x] Verify prod
  - [x] especially the `gp2` v. pure `aws-ebs`
  - [x] rest should be ignored (just labels and metadata)
- [x] Consider addressing the TODO regarding appcode that might change for prod
  - We should probably just include it in the service config; it would be used without any effect on automotive
  - We could also avoid the storage class issue this way
