### PR TITLE
Add nodejs-packaging-bundler to sandbox

### DIFF
--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -49,6 +49,8 @@
           - nss_wrapper
           # so people can manipulate their upstream fmf definitions while proposing downstream
           - fmf
+          # these are for node modules, requested for jowl
+          - nodejs-packaging-bundler
         state: present
         install_weak_deps: False
       tags:


### PR DESCRIPTION
Fedora's [Node.js packaging guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/Node.js/) require that node module dependencies of a package be bundled up in tarballs that are provided as separate Sources from the main package's source. It also recommends the nodejs-packaging-bundler package which provides scripts to automate this.

To automate this workflow with Packit, it is necessary to run nodejs-packaging-bundler as part of post-upstream-clone, which runs in the Sandcastle environment.

Therefore, add nodejs-packaging-bundler to the Sandscastle environment, for all packages, since there is no way yet to customize this from a .packit.yaml . The "jowl" package motivated this change, but it should be useful for any package with node module dependencies.

<!-- release notes for changelog/blog follow -->

Add nodejs-packaging-bundler to sandbox environment for packages with node module dependencies