### PR TITLE
fix: do not switch to workdir before running ansible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,9 @@ WORKDIR ${HOME}
 RUN chmod g+rwX .
 
 COPY files/container-cmd.sh files/setup_env_in_openshift.sh ./
+
+# wipe the mess from Ansible and Python…
+RUN rm -rf ./.cache ./.ansible
+
 # default command is sleep - so users can do .exec(command=[...])
 CMD ["./container-cmd.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ ENV PYTHONDONTWRITEBYTECODE=yes \
     USER=sandcastle \
     HOME=/home/sandcastle
 
-WORKDIR ${HOME}
-# So the arbitrary user ID can access it.
-RUN chmod g+rwX .
-
 COPY files/install-rpm-packages.yaml ./
 RUN ansible-playbook -vv -c local -t basic-image -i localhost, install-rpm-packages.yaml \
     && dnf clean all
+
+WORKDIR ${HOME}
+# So the arbitrary user ID can access it.
+RUN chmod g+rwX .
 
 COPY files/container-cmd.sh files/setup_env_in_openshift.sh ./
 # default command is sleep - so users can do .exec(command=[...])


### PR DESCRIPTION
When running Ansible, Python can create its own cache which can clash with the cache created during user's action in the sandbox. Namely creating such directory can easily result in broken permissions, since during the time of the creation of the image, it is being done with the highest permissions of `root`.

Therefore move the permission-fix and also switch of the work directory **after** the Ansible is run.

Related to cockpit-project/cockpit-machines#1350
