### PR TITLE
Add golang package to image for go-vendor-tools

### DIFF
--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -61,6 +61,7 @@
           # for go-vendor-tools
           - trivy
           - askalono-cli
+          - golang
         state: present
         install_weak_deps: False
       tags:


### PR DESCRIPTION
go-vendor-tools require the go command to create its vendor archives.

Ref: https://src.fedoraproject.org/rpms/docker-compose/pull-request/18
Ref: https://dashboard.packit.dev/jobs/pull-from-upstream/13188


---

Add `golang` package to sandcastle image to support go-vendor-tools. go-vendor-tools require the go command to create its vendor archives.
